### PR TITLE
Consistently implement Iterable<T>

### DIFF
--- a/src/java/simpledb/Catalog.java
+++ b/src/java/simpledb/Catalog.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * 
  * @Threadsafe
  */
-public class Catalog {
+public class Catalog implements Iterable<Integer> {
 
     /**
      * Constructor.
@@ -90,7 +90,10 @@ public class Catalog {
         return null;
     }
 
-    public Iterator<Integer> tableIdIterator() {
+    /**
+     * Returns an Iterator over the table IDs in this Catalog.
+     */
+    public Iterator<Integer> iterator() {
         // some code goes here
         return null;
     }

--- a/src/java/simpledb/HeapPage.java
+++ b/src/java/simpledb/HeapPage.java
@@ -11,7 +11,7 @@ import java.io.*;
  * @see BufferPool
  *
  */
-public class HeapPage implements Page {
+public class HeapPage implements Page, Iterable<Tuple> {
 
     final HeapPageId pid;
     final TupleDesc td;

--- a/src/java/simpledb/Tuple.java
+++ b/src/java/simpledb/Tuple.java
@@ -9,7 +9,7 @@ import java.util.Iterator;
  * specified schema specified by a TupleDesc object and contain Field objects
  * with the data for each field.
  */
-public class Tuple implements Serializable {
+public class Tuple implements Serializable, Iterable<Field> {
 
     private static final long serialVersionUID = 1L;
 
@@ -91,7 +91,7 @@ public class Tuple implements Serializable {
      * @return
      *        An iterator which iterates over all the fields of this tuple
      * */
-    public Iterator<Field> fields()
+    public Iterator<Field> iterator()
     {
         // some code goes here
         return null;

--- a/src/java/simpledb/TupleDesc.java
+++ b/src/java/simpledb/TupleDesc.java
@@ -6,7 +6,7 @@ import java.util.*;
 /**
  * TupleDesc describes the schema of a tuple.
  */
-public class TupleDesc implements Serializable {
+public class TupleDesc implements Serializable, Iterable<TDItem> {
 
     /**
      * A help class to facilitate organizing the information of each field


### PR DESCRIPTION
Many classes implement an `Iterator<T>`-returning method, but none of them declare their implementation of `Iterable<T>`. This PR mostly adds declarations (and renames one method in `Tuple`) to allow for the use of `Iterable<T>` features in Java, including "enhanced" for-loops.

Re: `Tuple.fields()`, I didn't find any call sites, but I don't know if the renaming breaks any unreleased tests. Just FYI.