### PR TITLE
Add TODO to placeholder comments

### DIFF
--- a/src/java/simpledb/BufferPool.java
+++ b/src/java/simpledb/BufferPool.java
@@ -32,7 +32,7 @@ public class BufferPool {
      * @param numPages maximum number of pages in this buffer pool.
      */
     public BufferPool(int numPages) {
-        // some code goes here
+        // TODO some code goes here
     }
     
     public static int getPageSize() {
@@ -66,7 +66,7 @@ public class BufferPool {
      */
     public  Page getPage(TransactionId tid, PageId pid, Permissions perm)
         throws TransactionAbortedException, DbException {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -80,7 +80,7 @@ public class BufferPool {
      * @param pid the ID of the page to unlock
      */
     public  void releasePage(TransactionId tid, PageId pid) {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1|lab2
     }
 
@@ -90,13 +90,13 @@ public class BufferPool {
      * @param tid the ID of the transaction requesting the unlock
      */
     public void transactionComplete(TransactionId tid) throws IOException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1|lab2
     }
 
     /** Return true if the specified transaction has a lock on the specified page */
     public boolean holdsLock(TransactionId tid, PageId p) {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1|lab2
         return false;
     }
@@ -110,7 +110,7 @@ public class BufferPool {
      */
     public void transactionComplete(TransactionId tid, boolean commit)
         throws IOException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1|lab2
     }
 
@@ -131,7 +131,7 @@ public class BufferPool {
      */
     public void insertTuple(TransactionId tid, int tableId, Tuple t)
         throws DbException, IOException, TransactionAbortedException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -150,7 +150,7 @@ public class BufferPool {
      */
     public  void deleteTuple(TransactionId tid, Tuple t)
         throws DbException, IOException, TransactionAbortedException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -160,7 +160,7 @@ public class BufferPool {
      *     break simpledb if running in NO STEAL mode.
      */
     public synchronized void flushAllPages() throws IOException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
 
     }
@@ -174,7 +174,7 @@ public class BufferPool {
         are removed from the cache so they can be reused safely
     */
     public synchronized void discardPage(PageId pid) {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -183,14 +183,14 @@ public class BufferPool {
      * @param pid an ID indicating the page to flush
      */
     private synchronized  void flushPage(PageId pid) throws IOException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
     /** Write all pages of the specified transaction to disk.
      */
     public synchronized  void flushPages(TransactionId tid) throws IOException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1|lab2
     }
 
@@ -199,7 +199,7 @@ public class BufferPool {
      * Flushes the page to disk to ensure dirty pages are updated on disk.
      */
     private synchronized  void evictPage() throws DbException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 

--- a/src/java/simpledb/Catalog.java
+++ b/src/java/simpledb/Catalog.java
@@ -23,7 +23,7 @@ public class Catalog {
      * Creates a new, empty catalog.
      */
     public Catalog() {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -36,7 +36,7 @@ public class Catalog {
      * @param pkeyField the name of the primary key field
      */
     public void addTable(DbFile file, String name, String pkeyField) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     public void addTable(DbFile file, String name) {
@@ -59,7 +59,7 @@ public class Catalog {
      * @throws NoSuchElementException if the table doesn't exist
      */
     public int getTableId(String name) throws NoSuchElementException {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -70,7 +70,7 @@ public class Catalog {
      * @throws NoSuchElementException if the table doesn't exist
      */
     public TupleDesc getTupleDesc(int tableid) throws NoSuchElementException {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -81,28 +81,28 @@ public class Catalog {
      *     function passed to addTable
      */
     public DbFile getDatabaseFile(int tableid) throws NoSuchElementException {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
     public String getPrimaryKey(int tableid) {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
     public Iterator<Integer> tableIdIterator() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
     public String getTableName(int id) {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
     
     /** Delete all tables from the catalog */
     public void clear() {
-        // some code goes here
+        // TODO some code goes here
     }
     
     /**

--- a/src/java/simpledb/HeapFile.java
+++ b/src/java/simpledb/HeapFile.java
@@ -23,7 +23,7 @@ public class HeapFile implements DbFile {
      *            file.
      */
     public HeapFile(File f, TupleDesc td) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -32,7 +32,7 @@ public class HeapFile implements DbFile {
      * @return the File backing this HeapFile on disk.
      */
     public File getFile() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -46,7 +46,7 @@ public class HeapFile implements DbFile {
      * @return an ID uniquely identifying this HeapFile.
      */
     public int getId() {
-        // some code goes here
+        // TODO some code goes here
         throw new UnsupportedOperationException("implement this");
     }
 
@@ -56,19 +56,19 @@ public class HeapFile implements DbFile {
      * @return TupleDesc of this DbFile.
      */
     public TupleDesc getTupleDesc() {
-        // some code goes here
+        // TODO some code goes here
         throw new UnsupportedOperationException("implement this");
     }
 
     // see DbFile.java for javadocs
     public Page readPage(PageId pid) {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
     // see DbFile.java for javadocs
     public void writePage(Page page) throws IOException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -76,14 +76,14 @@ public class HeapFile implements DbFile {
      * Returns the number of pages in this HeapFile.
      */
     public int numPages() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
     // see DbFile.java for javadocs
     public ArrayList<Page> insertTuple(TransactionId tid, Tuple t)
             throws DbException, IOException, TransactionAbortedException {
-        // some code goes here
+        // TODO some code goes here
         return null;
         // not necessary for lab1
     }
@@ -91,14 +91,14 @@ public class HeapFile implements DbFile {
     // see DbFile.java for javadocs
     public ArrayList<Page> deleteTuple(TransactionId tid, Tuple t) throws DbException,
             TransactionAbortedException {
-        // some code goes here
+        // TODO some code goes here
         return null;
         // not necessary for lab1
     }
 
     // see DbFile.java for javadocs
     public DbFileIterator iterator(TransactionId tid) {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 

--- a/src/java/simpledb/HeapPage.java
+++ b/src/java/simpledb/HeapPage.java
@@ -66,7 +66,7 @@ public class HeapPage implements Page {
         @return the number of tuples on this page
     */
     private int getNumTuples() {        
-        // some code goes here
+        // TODO some code goes here
         return 0;
 
     }
@@ -77,7 +77,7 @@ public class HeapPage implements Page {
      */
     private int getHeaderSize() {        
         
-        // some code goes here
+        // TODO some code goes here
         return 0;
                  
     }
@@ -111,7 +111,7 @@ public class HeapPage implements Page {
      * @return the PageId associated with this page.
      */
     public HeapPageId getId() {
-    // some code goes here
+    // TODO some code goes here
     throw new UnsupportedOperationException("implement this");
     }
 
@@ -243,7 +243,7 @@ public class HeapPage implements Page {
      * @param t The tuple to delete
      */
     public void deleteTuple(Tuple t) throws DbException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -255,7 +255,7 @@ public class HeapPage implements Page {
      * @param t The tuple to add.
      */
     public void insertTuple(Tuple t) throws DbException {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -264,7 +264,7 @@ public class HeapPage implements Page {
      * that did the dirtying
      */
     public void markDirty(boolean dirty, TransactionId tid) {
-        // some code goes here
+        // TODO some code goes here
 	// not necessary for lab1
     }
 
@@ -272,7 +272,7 @@ public class HeapPage implements Page {
      * Returns the tid of the transaction that last dirtied this page, or null if the page is not dirty
      */
     public TransactionId isDirty() {
-        // some code goes here
+        // TODO some code goes here
 	// Not necessary for lab1
         return null;      
     }
@@ -281,7 +281,7 @@ public class HeapPage implements Page {
      * Returns the number of empty slots on this page.
      */
     public int getNumEmptySlots() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -289,7 +289,7 @@ public class HeapPage implements Page {
      * Returns true if associated slot on this page is filled.
      */
     public boolean isSlotUsed(int i) {
-        // some code goes here
+        // TODO some code goes here
         return false;
     }
 
@@ -297,7 +297,7 @@ public class HeapPage implements Page {
      * Abstraction to fill or clear a slot on this page.
      */
     private void markSlotUsed(int i, boolean value) {
-        // some code goes here
+        // TODO some code goes here
         // not necessary for lab1
     }
 
@@ -306,7 +306,7 @@ public class HeapPage implements Page {
      * (note that this iterator shouldn't return tuples in empty slots!)
      */
     public Iterator<Tuple> iterator() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 

--- a/src/java/simpledb/HeapPageId.java
+++ b/src/java/simpledb/HeapPageId.java
@@ -11,12 +11,12 @@ public class HeapPageId implements PageId {
      * @param pgNo The page number in that table.
      */
     public HeapPageId(int tableId, int pgNo) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /** @return the table associated with this PageId */
     public int getTableId() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -25,7 +25,7 @@ public class HeapPageId implements PageId {
      *   this PageId
      */
     public int getPageNumber() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -36,7 +36,7 @@ public class HeapPageId implements PageId {
      * @see BufferPool
      */
     public int hashCode() {
-        // some code goes here
+        // TODO some code goes here
         throw new UnsupportedOperationException("implement this");
     }
 
@@ -48,7 +48,7 @@ public class HeapPageId implements PageId {
      *   ids are the same)
      */
     public boolean equals(Object o) {
-        // some code goes here
+        // TODO some code goes here
         return false;
     }
 

--- a/src/java/simpledb/LogFile.java
+++ b/src/java/simpledb/LogFile.java
@@ -466,7 +466,7 @@ public class LogFile {
         synchronized (Database.getBufferPool()) {
             synchronized(this) {
                 preAppend();
-                // some code goes here
+                // TODO some code goes here
             }
         }
     }
@@ -493,14 +493,14 @@ public class LogFile {
         synchronized (Database.getBufferPool()) {
             synchronized (this) {
                 recoveryUndecided = false;
-                // some code goes here
+                // TODO some code goes here
             }
          }
     }
 
     /** Print out a human readable represenation of the log */
     public void print() throws IOException {
-        // some code goes here
+        // TODO some code goes here
     }
 
     public  synchronized void force() throws IOException {

--- a/src/java/simpledb/Predicate.java
+++ b/src/java/simpledb/Predicate.java
@@ -55,7 +55,7 @@ public class Predicate implements Serializable {
      *            field value to compare passed in tuples to
      */
     public Predicate(int field, Op op, Field operand) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -63,7 +63,7 @@ public class Predicate implements Serializable {
      */
     public int getField()
     {
-        // some code goes here
+        // TODO some code goes here
         return -1;
     }
 
@@ -72,7 +72,7 @@ public class Predicate implements Serializable {
      */
     public Op getOp()
     {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
     
@@ -81,7 +81,7 @@ public class Predicate implements Serializable {
      */
     public Field getOperand()
     {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
     
@@ -96,7 +96,7 @@ public class Predicate implements Serializable {
      * @return true if the comparison is true, false otherwise.
      */
     public boolean filter(Tuple t) {
-        // some code goes here
+        // TODO some code goes here
         return false;
     }
 
@@ -105,7 +105,7 @@ public class Predicate implements Serializable {
      * operand_string"
      */
     public String toString() {
-        // some code goes here
+        // TODO some code goes here
         return "";
     }
 }

--- a/src/java/simpledb/RecordId.java
+++ b/src/java/simpledb/RecordId.java
@@ -20,14 +20,14 @@ public class RecordId implements Serializable {
      *            the tuple number within the page.
      */
     public RecordId(PageId pid, int tupleno) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
      * @return the tuple number this RecordId references.
      */
     public int getTupleNumber() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -35,7 +35,7 @@ public class RecordId implements Serializable {
      * @return the page id this RecordId references.
      */
     public PageId getPageId() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -47,7 +47,7 @@ public class RecordId implements Serializable {
      */
     @Override
     public boolean equals(Object o) {
-        // some code goes here
+        // TODO some code goes here
         throw new UnsupportedOperationException("implement this");
     }
 
@@ -59,7 +59,7 @@ public class RecordId implements Serializable {
      */
     @Override
     public int hashCode() {
-        // some code goes here
+        // TODO some code goes here
         throw new UnsupportedOperationException("implement this");
 
     }

--- a/src/java/simpledb/SeqScan.java
+++ b/src/java/simpledb/SeqScan.java
@@ -28,7 +28,7 @@ public class SeqScan implements OpIterator {
      *            tableAlias.null, or null.null).
      */
     public SeqScan(TransactionId tid, int tableid, String tableAlias) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -37,6 +37,7 @@ public class SeqScan implements OpIterator {
      *       be the actual name of the table in the catalog of the database
      * */
     public String getTableName() {
+        // TODO some code goes here
         return null;
     }
 
@@ -45,7 +46,7 @@ public class SeqScan implements OpIterator {
      * */
     public String getAlias()
     {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -62,7 +63,7 @@ public class SeqScan implements OpIterator {
      *            tableAlias.null, or null.null).
      */
     public void reset(int tableid, String tableAlias) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     public SeqScan(TransactionId tid, int tableId) {
@@ -70,7 +71,7 @@ public class SeqScan implements OpIterator {
     }
 
     public void open() throws DbException, TransactionAbortedException {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -84,27 +85,27 @@ public class SeqScan implements OpIterator {
      *         prefixed with the tableAlias string from the constructor.
      */
     public TupleDesc getTupleDesc() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
     public boolean hasNext() throws TransactionAbortedException, DbException {
-        // some code goes here
+        // TODO some code goes here
         return false;
     }
 
     public Tuple next() throws NoSuchElementException,
             TransactionAbortedException, DbException {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
     public void close() {
-        // some code goes here
+        // TODO some code goes here
     }
 
     public void rewind() throws DbException, NoSuchElementException,
             TransactionAbortedException {
-        // some code goes here
+        // TODO some code goes here
     }
 }

--- a/src/java/simpledb/Tuple.java
+++ b/src/java/simpledb/Tuple.java
@@ -21,14 +21,14 @@ public class Tuple implements Serializable {
      *            instance with at least one field.
      */
     public Tuple(TupleDesc td) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
      * @return The TupleDesc representing the schema of this tuple.
      */
     public TupleDesc getTupleDesc() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -37,7 +37,7 @@ public class Tuple implements Serializable {
      *         be null.
      */
     public RecordId getRecordId() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -48,7 +48,7 @@ public class Tuple implements Serializable {
      *            the new RecordId for this tuple.
      */
     public void setRecordId(RecordId rid) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -60,7 +60,7 @@ public class Tuple implements Serializable {
      *            new value for the field.
      */
     public void setField(int i, Field f) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -70,7 +70,7 @@ public class Tuple implements Serializable {
      *            field index to return. Must be a valid index.
      */
     public Field getField(int i) {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -83,7 +83,7 @@ public class Tuple implements Serializable {
      * where \t is any whitespace (except a newline)
      */
     public String toString() {
-        // some code goes here
+        // TODO some code goes here
         throw new UnsupportedOperationException("Implement this");
     }
 
@@ -93,7 +93,7 @@ public class Tuple implements Serializable {
      * */
     public Iterator<Field> fields()
     {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -102,6 +102,6 @@ public class Tuple implements Serializable {
      * */
     public void resetTupleDesc(TupleDesc td)
     {
-        // some code goes here
+        // TODO some code goes here
     }
 }

--- a/src/java/simpledb/TupleDesc.java
+++ b/src/java/simpledb/TupleDesc.java
@@ -41,7 +41,7 @@ public class TupleDesc implements Serializable {
      *        that are included in this TupleDesc
      * */
     public Iterator<TDItem> iterator() {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -59,7 +59,7 @@ public class TupleDesc implements Serializable {
      *            be null.
      */
     public TupleDesc(Type[] typeAr, String[] fieldAr) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
@@ -71,14 +71,14 @@ public class TupleDesc implements Serializable {
      *            TupleDesc. It must contain at least one entry.
      */
     public TupleDesc(Type[] typeAr) {
-        // some code goes here
+        // TODO some code goes here
     }
 
     /**
      * @return the number of fields in this TupleDesc
      */
     public int numFields() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -92,7 +92,7 @@ public class TupleDesc implements Serializable {
      *             if i is not a valid field reference.
      */
     public String getFieldName(int i) throws NoSuchElementException {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -107,7 +107,7 @@ public class TupleDesc implements Serializable {
      *             if i is not a valid field reference.
      */
     public Type getFieldType(int i) throws NoSuchElementException {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -121,7 +121,7 @@ public class TupleDesc implements Serializable {
      *             if no field with a matching name is found.
      */
     public int fieldNameToIndex(String name) throws NoSuchElementException {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -130,7 +130,7 @@ public class TupleDesc implements Serializable {
      *         Note that tuples from a given TupleDesc are of a fixed size.
      */
     public int getSize() {
-        // some code goes here
+        // TODO some code goes here
         return 0;
     }
 
@@ -145,7 +145,7 @@ public class TupleDesc implements Serializable {
      * @return the new TupleDesc
      */
     public static TupleDesc merge(TupleDesc td1, TupleDesc td2) {
-        // some code goes here
+        // TODO some code goes here
         return null;
     }
 
@@ -161,7 +161,7 @@ public class TupleDesc implements Serializable {
      */
 
     public boolean equals(Object o) {
-        // some code goes here
+        // TODO some code goes here
         return false;
     }
 
@@ -179,7 +179,7 @@ public class TupleDesc implements Serializable {
      * @return String describing this descriptor.
      */
     public String toString() {
-        // some code goes here
+        // TODO some code goes here
         return "";
     }
 }


### PR DESCRIPTION
This PR adds `TODO` to all of the comments that say `some code goes here`. I found that these comments were easy to miss, and besides which, most editors and IDEs help keep track of `TODO`s so they're nice to have anyway.

One comment was added to `SeqScan.getTableName()` that I thought was missing.

A preferable further step would be to `throw new UnsupportedOperationException("unimplemented")` instead of failing silently, but that'd be a separate PR, please let me know how you feel.